### PR TITLE
Fix spherization of URDF with sphere primitives

### DIFF
--- a/foam/__init__.py
+++ b/foam/__init__.py
@@ -3,6 +3,7 @@ from json import load as jsload
 from json import dumps as jsdumps
 from concurrent.futures import ThreadPoolExecutor, Future
 from concurrent.futures import wait as future_wait
+from trimesh.primitives import Sphere as TMSphere
 
 from .utility import *
 from .external import *
@@ -34,6 +35,19 @@ def spherize_mesh(
         loaded_mesh = mesh
 
     loaded_mesh = loaded_mesh.copy()
+
+    if isinstance(mesh, TMSphere):
+        x, y, z = mesh.center
+        r = mesh.primitive.radius
+        return [
+            Spherization(
+                spheres=[Sphere(x, y, z, r)],
+                mean_error=0.0,
+                best_error=0.0,
+                worst_error=0.0,
+            )
+        ] * (spherization_kwargs["depth"] + 1)
+        # NOTE: Because depth seems to be 0-indexed and determines the number of fineness levels for the spherization
 
     if position is not None or orientation is not None:
         tf = compose_matrix(angles=orientation, translate=position)

--- a/foam/__init__.py
+++ b/foam/__init__.py
@@ -21,17 +21,21 @@ def smooth_manifold(mesh: Trimesh, manifold_leaves: int = 1000, ratio = 0.2) -> 
 
 
 def spherize_mesh(
-        mesh: Trimesh | Path,
-        scale: NDArray | None = None,
-        position: NDArray | None = None,
-        orientation: NDArray | None = None,
-        spherization_kwargs: dict[str, Any] = {},
-        process_kwargs: dict[str, Any] = {}
-    ) -> list[Spherization]:
+    name: str,
+    mesh: Trimesh | Path,
+    scale: NDArray | None = None,
+    position: NDArray | None = None,
+    orientation: NDArray | None = None,
+    spherization_kwargs: dict[str, Any] = {},
+    process_kwargs: dict[str, Any] = {},
+) -> list[Spherization]:
 
+    print(f"Spherizing {name}")
     if isinstance(mesh, Path):
+        print(f"Processing {mesh}")
         loaded_mesh = load_mesh_file(mesh)
     else:
+        print("Processing pre-loaded mesh")
         loaded_mesh = mesh
 
     loaded_mesh = loaded_mesh.copy()
@@ -102,8 +106,15 @@ class ParallelSpherizer:
             process_kwargs: dict[str, Any] = {}
         ) -> Future[list[Spherization]]:
         future = self.executor.submit(
-            spherize_mesh, mesh, scale, position, orientation, spherization_kwargs, process_kwargs
-            )
+            spherize_mesh,
+            name,
+            mesh,
+            scale,
+            position,
+            orientation,
+            spherization_kwargs,
+            process_kwargs,
+        )
 
         self.waiting[name] = future
         return future

--- a/foam/external/__init__.py
+++ b/foam/external/__init__.py
@@ -57,10 +57,10 @@ def compute_spheres_helper(mesh: Trimesh, command: list[str],method) -> list[Sph
 
         output_file = input_path.parent / (input_path.stem + f'-{method}.sph')
         # print(command)
-        run(command + [str(input_path)], stdout = DEVNULL)
+        sphere_output = run(command + [str(input_path)], capture_output=True)
 
-    if not output_file.exists():
-        raise RuntimeError("Failed to create spheres for mesh. Mesh is probably invalid.")
+    if sphere_output.returncode != 0:
+        raise RuntimeError(f"Failed to create spheres for mesh. Mesh is probably invalid. {sphere_output.stdout}")
 
     low_bounds, high_bounds = mesh.bounds
     offset = (high_bounds + low_bounds) / 2

--- a/scripts/generate_spheres.py
+++ b/scripts/generate_spheres.py
@@ -70,6 +70,7 @@ def main(
 
     # Call spherize_mesh with the updated kwargs
     spheres = spherize_mesh(
+        mesh,
         mesh_filepath,
         scale=np.array([scale] * 3),
         spherization_kwargs=spherization_kwargs,


### PR DESCRIPTION
When attempting to spherize a URDF for the BD Spot, I noticed that `foam` crashes due to the inclusion of primitive spheres in the URDF's collision geometry. Since it seems like we should never try to spherize a sphere, this PR adds logic to create a trivial spherization for primitive spheres.

It also includes some QoL improvements that were useful while debugging.

Note: this bug may point to deeper issues with spherizing primitives, but I haven't tested that at all yet. Might be good to add some examples to CI?
