### PR TITLE
fix(cmake): explicitly link pthread

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -19,7 +19,9 @@ add_executable(
     manifold_old/src/Octree.h
 )
 
+find_package(Threads REQUIRED)
 add_executable(
     simplify_old
     manifold_old/src/simplify.cpp
 )
+target_link_libraries(simplify_old PRIVATE Threads::Threads)


### PR DESCRIPTION
## What is this
On my Ubuntu 20.04 environment, in the end of the making process, liking pthread to simplify_old fails.
```
[100%] Linking CXX executable simplify_old
/usr/bin/ld: /tmp/simplify_old.cVRFIK.ltrans0.ltrans.o: in function `void igl::unique_simplices<Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, -1, 0, -1, -1>, Eigen::Matrix<int, -1, 1, 0, -1, 1>, Eigen::Matrix<int, -1, 1, 0, -1, 1> >(Eigen::MatrixBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> > const&, Eigen::PlainObjectBase<Eigen::Matrix<int, -1, -1, 0, -1, -1> >&, Eigen::PlainObjectBase<Eigen::Matrix<int, -1, 1, 0, -1, 1> >&, Eigen::PlainObjectBase<Eigen::Matrix<int, -1, 1, 0, -1, 1> >&) [clone .constprop.0]':
<artificial>:(.text+0xdcbb): undefined reference to `pthread_create'
/usr/bin/ld: <artificial>:(.text+0xe6ab): undefined reference to `pthread_create'
/usr/bin/ld: /tmp/simplify_old.cVRFIK.ltrans2.ltrans.o: in function `_ZNSt6vectorISt6threadSaIS0_EE12emplace_backIJRKZN3igl12parallel_forIiZNS4_12parallel_forIiZNS4_5sort3IN5Eigen6MatrixIiLin1ELin1ELi0ELin1ELin1EEESA_SA_EEvRKNS8_9DenseBaseIT_EEibRNS8_15PlainObjectBaseIT0_EERNSG_IT1_EEEUlRKiE_EEbSC_RKSH_mEUlmE_ZNS6_IiSP_EEbSC_SR_mEUlimE0_SS_EEbSC_SR_RKSK_RKT2_mEUliimE_RiS12_RmEEEvDpOT_':
<artificial>:(.text+0x25e5): undefined reference to `pthread_create'
/usr/bin/ld: <artificial>:(.text+0x2703): undefined reference to `pthread_create'
/usr/bin/ld: /tmp/simplify_old.cVRFIK.ltrans2.ltrans.o: in function `_ZNSt6vectorISt6threadSaIS0_EE17_M_realloc_insertIJRKZN3igl12parallel_forImZNS4_12parallel_forImZNS4_16unique_simplicesIN5Eigen6MatrixIiLin1ELin1ELi0ELin1ELin1EEESA_NS9_IiLin1ELi1ELi0ELin1ELi1EEESB_EEvRKNS8_10MatrixBaseIT_EERNS8_15PlainObjectBaseIT0_EERNSH_IT1_EERNSH_IT2_EEEUlRmE_EEbSD_RKSI_mEUlmE_ZNS6_ImSS_EEbSD_SU_mEUlmmE0_SV_EEbSD_SU_RKSL_RKSO_mEUlmmmE_SR_SR_SR_EEEvN9__gnu_cxx17__normal_iteratorIPS0_S2_EEDpOT_':
<artificial>:(.text+0x32ef): undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make[2]: *** [external/CMakeFiles/simplify_old.dir/build.make:100: external/simplify_old] Error 1
make[1]: *** [CMakeFiles/Makefile2:584: external/CMakeFiles/simplify_old.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
This PR fixes this issue. I also tested that the build fails on clean ubuntu 20.04 docker container environment, and build passes on ubuntu 22.04 clean environment.

## Info
Just for the reference this is my environment, where I encounter the above error:
```
h-ishida@umejuice:~/python/foam/build$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.6 LTS
Release:	20.04
Codename:	focal
h-ishida@umejuice:~/python/foam/build$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.6 LTS
Release:	20.04
Codename:	focal
h-ishida@umejuice:~/python/foam/build$ g++ --version
g++ (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

h-ishida@umejuice:~/python/foam/build$ which ld
/usr/bin/ld
h-ishida@umejuice:~/python/foam/build$ ld --version
GNU ld (GNU Binutils for Ubuntu) 2.34
Copyright (C) 2020 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
h-ishida@umejuice:~/python/foam/build$ cmake --version
cmake version 3.31.3

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```