### PR TITLE
fix(submodules): switch URLs to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/manifold"]
 	path = external/manifold
-	url = git@github.com:hjwdzh/ManifoldPlus.git
+	url = https://github.com/hjwdzh/ManifoldPlus.git
 [submodule "external/simplify"]
 	path = external/simplify
-	url = git@github.com:sp4cerat/Fast-Quadric-Mesh-Simplification.git
+	url = https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification.git
 [submodule "external/manifold_old"]
 	path = external/manifold_old
-	url = git@github.com:hjwdzh/Manifold.git
+	url = https://github.com/hjwdzh/Manifold.git


### PR DESCRIPTION
##  What's this
Originally, the submodule’s URL was an SSH URL, which required a registered SSH key.
This PR changes it to an HTTPS URL, eliminating the need for an SSH key.

## Check
I also checked, that it works on the clean docker environment:
```
root@dde835f97440:~# rm -rf .ssh
root@dde835f97440:~# git clone -b fix_submodule_link https://github.com/HiroIshida/foam.git --recursive
Cloning into 'foam'...
remote: Enumerating objects: 6946, done.
remote: Counting objects: 100% (170/170), done.
remote: Compressing objects: 100% (120/120), done.
remote: Total 6946 (delta 87), reused 53 (delta 50), pack-reused 6776 (from 3)
Receiving objects: 100% (6946/6946), 183.52 MiB | 18.92 MiB/s, done.
Resolving deltas: 100% (1654/1654), done.
Submodule 'external/manifold' (https://github.com/hjwdzh/ManifoldPlus.git) registered for path 'external/manifold'
Submodule 'external/manifold_old' (https://github.com/hjwdzh/Manifold.git) registered for path 'external/manifold_old'
Submodule 'external/simplify' (https://github.com/sp4cerat/Fast-Quadric-Mesh-Simplification.git) registered for path 'external/simplify'
Cloning into '/root/foam/external/manifold'...
remote: Enumerating objects: 148, done.        
remote: Counting objects: 100% (58/58), done.        
remote: Compressing objects: 100% (15/15), done.        
remote: Total 148 (delta 49), reused 43 (delta 43), pack-reused 90 (from 1)        
Receiving objects: 100% (148/148), 812.12 KiB | 12.69 MiB/s, done.
Resolving deltas: 100% (76/76), done.
Cloning into '/root/foam/external/manifold_old'...
remote: Enumerating objects: 2121, done.        
remote: Total 2121 (delta 0), reused 0 (delta 0), pack-reused 2121 (from 1)        
Receiving objects: 100% (2121/2121), 4.45 MiB | 20.79 MiB/s, done.
Resolving deltas: 100% (521/521), done.
Cloning into '/root/foam/external/simplify'...
remote: Enumerating objects: 1063, done.        
remote: Counting objects: 100% (137/137), done.        
remote: Compressing objects: 100% (32/32), done.        
remote: Total 1063 (delta 120), reused 105 (delta 105), pack-reused 926 (from 2)        
Receiving objects: 100% (1063/1063), 14.49 MiB | 20.33 MiB/s, done.
Resolving deltas: 100% (224/224), done.
Submodule path 'external/manifold': checked out 'a0cc6d9817f81efff63b704a2fed53567ea44cbd'
Submodule '3rd_party/eigen' (https://gitlab.com/libeigen/eigen.git) registered for path 'external/manifold/3rd_party/eigen'
Submodule '3rd_party/libigl' (https://github.com/libigl/libigl) registered for path 'external/manifold/3rd_party/libigl'
Cloning into '/root/foam/external/manifold/3rd_party/eigen'...
remote: Enumerating objects: 128654, done.        
remote: Counting objects: 100% (250/250), done.        
remote: Compressing objects: 100% (109/109), done.        
remote: Total 128654 (delta 141), reused 244 (delta 139), pack-reused 128404 (from 1)        
Receiving objects: 100% (128654/128654), 106.57 MiB | 28.41 MiB/s, done.
Resolving deltas: 100% (106776/106776), done.
Cloning into '/root/foam/external/manifold/3rd_party/libigl'...
remote: Enumerating objects: 45092, done.        
remote: Counting objects: 100% (1175/1175), done.        
remote: Compressing objects: 100% (576/576), done.        
remote: Total 45092 (delta 815), reused 599 (delta 599), pack-reused 43917 (from 3)        
Receiving objects: 100% (45092/45092), 13.24 MiB | 19.73 MiB/s, done.
Resolving deltas: 100% (27569/27569), done.
Submodule path 'external/manifold/3rd_party/eigen': checked out '74ec8e6618c02a71dba28029b33dbe2a3f4da590'
Submodule path 'external/manifold/3rd_party/libigl': checked out 'd402d9495995d6324085a1ec5934961f7211ba12'
Submodule path 'external/manifold_old': checked out '81fd342e578e29fc15fb75d2b4d1e3c821fe33cb'
Submodule path 'external/simplify': checked out '2927c8209be291088b939cd934f1b69844922f26'
root@dde835f97440:~# echo $?
0
```